### PR TITLE
Remove rules for strict selector checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,5 @@ module.exports = {
     "react-native/css-property-no-unknown": true,
     "value-no-vendor-prefix": true,
     "property-no-vendor-prefix": true,
-    "selector-max-id": 0,
-    "selector-max-attribute": 0,
-    "selector-max-universal": 0,
-    "selector-max-type": 0,
-    "selector-max-combinators": 0,
-    "selector-no-qualifying-type": true,
-    "selector-pseudo-class-whitelist": [],
   },
 };

--- a/index.test.js
+++ b/index.test.js
@@ -57,9 +57,10 @@ describe("stylelint-config-react-native-css-modules", () => {
       });
   });
 
-  it("does not allow id selectors", () => {
-    const css = "#test { flex: 1 }";
-    expect.assertions(2);
+  it("allows pseudo and type selectors (ignored by React Native CSS modules, but can be used for web when creating hybrid apps)", () => {
+    const css =
+      ".test:hover { color: blue; } .test input[type=text] { color: red; }";
+    expect.assertions(1);
 
     return stylelint
       .lint({
@@ -70,121 +71,7 @@ describe("stylelint-config-react-native-css-modules", () => {
         },
       })
       .then(result => {
-        expect(result.errored).toBe(true);
-        expect(result.output.includes("selector-max-id")).toBe(true);
-      });
-  });
-
-  it("does not allow type selectors", () => {
-    const css = "input { flex: 1 }";
-    expect.assertions(2);
-
-    return stylelint
-      .lint({
-        code: css,
-        formatter: "string",
-        config: {
-          extends: "./index",
-        },
-      })
-      .then(result => {
-        expect(result.errored).toBe(true);
-        expect(result.output.includes("selector-max-type")).toBe(true);
-      });
-  });
-
-  it("does not allow universal selectors", () => {
-    const css = "* { flex: 1 }";
-    expect.assertions(2);
-
-    return stylelint
-      .lint({
-        code: css,
-        formatter: "string",
-        config: {
-          extends: "./index",
-        },
-      })
-      .then(result => {
-        expect(result.errored).toBe(true);
-        expect(result.output.includes("selector-max-universal")).toBe(true);
-      });
-  });
-
-  it("does not allow combinator selectors", () => {
-    const css = ".foo + .bar { flex: 1 }";
-    expect.assertions(2);
-
-    return stylelint
-      .lint({
-        code: css,
-        formatter: "string",
-        config: {
-          extends: "./index",
-        },
-      })
-      .then(result => {
-        expect(result.errored).toBe(true);
-        expect(result.output.includes("selector-max-combinators")).toBe(true);
-      });
-  });
-
-  it("does not allow attribute selectors", () => {
-    const css = "[type='text'] { flex: 1 }";
-    expect.assertions(2);
-
-    return stylelint
-      .lint({
-        code: css,
-        formatter: "string",
-        config: {
-          extends: "./index",
-        },
-      })
-      .then(result => {
-        expect(result.errored).toBe(true);
-        expect(result.output.includes("selector-max-attribute")).toBe(true);
-      });
-  });
-
-  it("does not allow qualifying type selectors", () => {
-    const css = "a.link { flex: 1 }";
-    expect.assertions(3);
-
-    return stylelint
-      .lint({
-        code: css,
-        formatter: "string",
-        config: {
-          extends: "./index",
-        },
-      })
-      .then(result => {
-        expect(result.errored).toBe(true);
-        expect(result.output.includes("selector-max-type")).toBe(true);
-        expect(result.output.includes("selector-no-qualifying-type")).toBe(
-          true,
-        );
-      });
-  });
-
-  it("does not allow pseudo classes", () => {
-    const css = ".foo:before { flex: 1 }";
-    expect.assertions(2);
-
-    return stylelint
-      .lint({
-        code: css,
-        formatter: "string",
-        config: {
-          extends: "./index",
-        },
-      })
-      .then(result => {
-        expect(result.errored).toBe(true);
-        expect(result.output.includes("selector-pseudo-class-whitelist")).toBe(
-          true,
-        );
+        expect(result.errored).toBe(false);
       });
   });
 });


### PR DESCRIPTION
React Native CSS modules ignore selectors other than basic classes. This is why all kinds of selectors should be allowed, as they can be used used to target web.

e.g. Use `.myClass:hover` to add hover for web only.