### PR TITLE
Enable more errors and warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ Create the `.stylelintrc` config file (or open the existing one) and extend `sty
 
 ## Custom settings
 
-The config enables by default warnings for CSS selectors that are not compatible with React Native CSS modules.
+The config enables by default warnings for at-rules, units, CSS selectors that are not compatible with React Native CSS modules.
 
-If you want to turn off the CSS selector warnings, you can use the following config:
+If you want to turn off the warnings, you can use the following config:
 
 ```json
 {
   "extends": "stylelint-config-react-native-css-modules",
   "rules": {
+    "at-rule-blacklist": null,
+    "unit-whitelist": null,
     "selector-pseudo-class-whitelist": null,
     "selector-max-universal": null,
     "selector-max-attribute": null,
@@ -55,58 +57,66 @@ If you want to turn off the CSS selector warnings, you can use the following con
 }
 ```
 
-If you want the CSS selector warnings to be turned into stylelint errors, you can use the following config:
+If you want to change the at-rule, unit, and CSS selector warnings into stylelint errors (e.g. If you are using React Native only), you can use the following config:
 
 ```json
 {
   "extends": "stylelint-config-react-native-css-modules",
   "rules": {
+    "at-rule-blacklist": [
+      ["keyframes", "font-face", "supports"],
+      {
+        "severity": "error",
+        "message": "the @-rule is ignored by React Native CSS modules. You can use it for Web when sharing the styles between React Native and browser."
+      }
+    ],
+    "unit-whitelist": [
+      ["px", "rem", "deg", "%"],
+      {
+        "severity": "error",
+        "message": "the unit is ignored by React Native CSS modules. You can use it for Web when sharing the styles between React Native and browser."
+      }
+    ],
     "selector-pseudo-class-whitelist": [
       [],
       {
         "severity": "error",
-        "message":
-          "pseudo class selectors are ignored by React Native CSS modules. You may still use them for web."
+        "message": "pseudo class selectors are ignored by React Native CSS modules. You can use them for Web when sharing the styles between React Native and browser."
       }
     ],
     "selector-max-universal": [
       0,
       {
         "severity": "error",
-        "message":
-          "universal selectors are ignored by React Native CSS modules. You may still use them for web."
+        "message": "universal selectors are ignored by React Native CSS modules. You can use them for Web when sharing the styles between React Native and browser."
       }
     ],
     "selector-max-attribute": [
       0,
       {
         "severity": "error",
-        "message":
-          "attribute selectors are ignored by React Native CSS modules. You may still use them for web."
+        "message": "attribute selectors are ignored by React Native CSS modules. You can use them for Web when sharing the styles between React Native and browser."
       }
     ],
     "selector-max-type": [
       0,
       {
         "severity": "error",
-        "message":
-          "type selectors are ignored by React Native CSS modules. You may still use them for web."
+        "message": "type selectors are ignored by React Native CSS modules. You can use them for Web when sharing the styles between React Native and browser."
       }
     ],
     "selector-max-combinators": [
       0,
       {
         "severity": "error",
-        "message":
-          "combinator selectors are ignored by React Native CSS modules. You may still use them for web."
+        "message": "combinator selectors are ignored by React Native CSS modules. You can use them for Web when sharing the styles between React Native and browser."
       }
     ],
     "selector-max-id": [
       0,
       {
         "severity": "error",
-        "message":
-          "id selectors are ignored by React Native CSS modules. You may still use them for web."
+        "message": "id selectors are ignored by React Native CSS modules. You can use them for Web when sharing the styles between React Native and browser."
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If you want to turn off the warnings, you can use the following config:
 {
   "extends": "stylelint-config-react-native-css-modules",
   "rules": {
+    "react-native/font-weight-no-ignored-values": null,
     "at-rule-blacklist": null,
     "unit-whitelist": null,
     "selector-pseudo-class-whitelist": null,

--- a/index.js
+++ b/index.js
@@ -2,55 +2,81 @@ module.exports = {
   plugins: ["stylelint-react-native"],
   rules: {
     "react-native/css-property-no-unknown": true,
+    "react-native/font-weight-no-ignored-values": [
+      true,
+      {
+        severity: "warning",
+        message:
+          "font-weight value other than 400, 700, normal or bold has not effect in React Native on Android. You can use it for Web when sharing the styles between React Native and browser."
+      }
+    ],
     "value-no-vendor-prefix": true,
     "property-no-vendor-prefix": true,
+    "at-rule-no-vendor-prefix": true,
+    "media-feature-name-no-vendor-prefix": true,
+    "at-rule-blacklist": [
+      ["keyframes", "font-face", "supports"],
+      {
+        severity: "warning",
+        message:
+          "the @-rule is ignored by React Native CSS modules. You can use it for Web when sharing the styles between React Native and browser."
+      }
+    ],
+    "unit-whitelist": [
+      ["px", "rem", "deg", "%"],
+      {
+        severity: "warning",
+        message:
+          "the unit is ignored by React Native CSS modules. You can use it for Web when sharing the styles between React Native and browser."
+      }
+    ],
     "selector-pseudo-class-whitelist": [
       [],
       {
         severity: "warning",
         message:
-          "pseudo class selectors are ignored by React Native CSS modules. You may still use them for web.",
-      },
+          "pseudo class selectors are ignored by React Native CSS modules. You can use them for Web when sharing the styles between React Native and browser."
+      }
     ],
     "selector-max-universal": [
       0,
       {
         severity: "warning",
         message:
-          "universal selectors are ignored by React Native CSS modules. You may still use them for web.",
-      },
+          "universal selectors are ignored by React Native CSS modules. You can use them for Web when sharing the styles between React Native and browser."
+      }
     ],
     "selector-max-attribute": [
       0,
       {
         severity: "warning",
         message:
-          "attribute selectors are ignored by React Native CSS modules. You may still use them for web.",
-      },
+          "attribute selectors are ignored by React Native CSS modules. You can use them for Web when sharing the styles between React Native and browser."
+      }
     ],
     "selector-max-type": [
       0,
       {
         severity: "warning",
         message:
-          "type selectors are ignored by React Native CSS modules. You may still use them for web.",
-      },
+          "type selectors are ignored by React Native CSS modules. You can use them for Web when sharing the styles between React Native and browser."
+      }
     ],
     "selector-max-combinators": [
       0,
       {
         severity: "warning",
         message:
-          "combinator selectors are ignored by React Native CSS modules. You may still use them for web.",
-      },
+          "combinator selectors are ignored by React Native CSS modules. You can use them for Web when sharing the styles between React Native and browser."
+      }
     ],
     "selector-max-id": [
       0,
       {
         severity: "warning",
         message:
-          "id selectors are ignored by React Native CSS modules. You may still use them for web.",
-      },
-    ],
-  },
+          "id selectors are ignored by React Native CSS modules. You can use them for Web when sharing the styles between React Native and browser."
+      }
+    ]
+  }
 };

--- a/index.test.js
+++ b/index.test.js
@@ -245,7 +245,7 @@ describe("stylelint-config-react-native-css-modules", () => {
       })
       .then(result => {
         expect(result.errored).toBe(false);
-        expect(result.output.includes("weight value other than")).toBe(true);
+        expect(result.output.includes("font-weight value")).toBe(true);
       });
   });
 

--- a/index.test.js
+++ b/index.test.js
@@ -245,9 +245,7 @@ describe("stylelint-config-react-native-css-modules", () => {
       })
       .then(result => {
         expect(result.errored).toBe(false);
-        expect(result.output.includes("font-weight value other than")).toBe(
-          true
-        );
+        expect(result.output.includes("weight value other than")).toBe(true);
       });
   });
 

--- a/index.test.js
+++ b/index.test.js
@@ -10,8 +10,8 @@ describe("stylelint-config-react-native-css-modules", () => {
         code: css,
         formatter: "string",
         config: {
-          extends: "./index",
-        },
+          extends: "./index"
+        }
       })
       .then(result => {
         expect(result.errored).toBe(true);
@@ -28,12 +28,52 @@ describe("stylelint-config-react-native-css-modules", () => {
         code: css,
         formatter: "string",
         config: {
-          extends: "./index",
-        },
+          extends: "./index"
+        }
       })
       .then(result => {
         expect(result.errored).toBe(true);
         expect(result.output.includes("property-no-vendor-prefix")).toBe(true);
+      });
+  });
+
+  it("does not allow vendor prefixes in at-rules", () => {
+    const css =
+      ".test { @-webkit-keyframes() { 0% { color: blue } 100% { color: red; } }  }";
+    expect.assertions(2);
+
+    return stylelint
+      .lint({
+        code: css,
+        formatter: "string",
+        config: {
+          extends: "./index"
+        }
+      })
+      .then(result => {
+        expect(result.errored).toBe(true);
+        expect(result.output.includes("at-rule-no-vendor-prefix")).toBe(true);
+      });
+  });
+
+  it("does not allow vendor prefixes in media features", () => {
+    const css =
+      "@media (-webkit-min-device-pixel-ratio: 1) { .foo { color: blue; } }";
+    expect.assertions(2);
+
+    return stylelint
+      .lint({
+        code: css,
+        formatter: "string",
+        config: {
+          extends: "./index"
+        }
+      })
+      .then(result => {
+        expect(result.errored).toBe(true);
+        expect(
+          result.output.includes("media-feature-name-no-vendor-prefix")
+        ).toBe(true);
       });
   });
 
@@ -46,13 +86,13 @@ describe("stylelint-config-react-native-css-modules", () => {
         code: css,
         formatter: "string",
         config: {
-          extends: "./index",
-        },
+          extends: "./index"
+        }
       })
       .then(result => {
         expect(result.errored).toBe(true);
         expect(
-          result.output.includes("react-native/css-property-no-unknown"),
+          result.output.includes("react-native/css-property-no-unknown")
         ).toBe(true);
       });
   });
@@ -66,8 +106,8 @@ describe("stylelint-config-react-native-css-modules", () => {
         code: css,
         formatter: "string",
         config: {
-          extends: "./index",
-        },
+          extends: "./index"
+        }
       })
       .then(result => {
         expect(result.errored).toBe(false);
@@ -84,8 +124,8 @@ describe("stylelint-config-react-native-css-modules", () => {
         code: css,
         formatter: "string",
         config: {
-          extends: "./index",
-        },
+          extends: "./index"
+        }
       })
       .then(result => {
         expect(result.errored).toBe(false);
@@ -102,13 +142,13 @@ describe("stylelint-config-react-native-css-modules", () => {
         code: css,
         formatter: "string",
         config: {
-          extends: "./index",
-        },
+          extends: "./index"
+        }
       })
       .then(result => {
         expect(result.errored).toBe(false);
         expect(result.output.includes("universal selectors are ignored")).toBe(
-          true,
+          true
         );
       });
   });
@@ -122,13 +162,13 @@ describe("stylelint-config-react-native-css-modules", () => {
         code: css,
         formatter: "string",
         config: {
-          extends: "./index",
-        },
+          extends: "./index"
+        }
       })
       .then(result => {
         expect(result.errored).toBe(false);
         expect(result.output.includes("combinator selectors are ignored")).toBe(
-          true,
+          true
         );
       });
   });
@@ -142,13 +182,13 @@ describe("stylelint-config-react-native-css-modules", () => {
         code: css,
         formatter: "string",
         config: {
-          extends: "./index",
-        },
+          extends: "./index"
+        }
       })
       .then(result => {
         expect(result.errored).toBe(false);
         expect(result.output.includes("attribute selectors are ignored")).toBe(
-          true,
+          true
         );
       });
   });
@@ -162,8 +202,8 @@ describe("stylelint-config-react-native-css-modules", () => {
         code: css,
         formatter: "string",
         config: {
-          extends: "./index",
-        },
+          extends: "./index"
+        }
       })
       .then(result => {
         expect(result.errored).toBe(false);
@@ -180,13 +220,80 @@ describe("stylelint-config-react-native-css-modules", () => {
         code: css,
         formatter: "string",
         config: {
-          extends: "./index",
-        },
+          extends: "./index"
+        }
       })
       .then(result => {
         expect(result.errored).toBe(false);
         expect(
-          result.output.includes("pseudo class selectors are ignored"),
+          result.output.includes("pseudo class selectors are ignored")
+        ).toBe(true);
+      });
+  });
+
+  it("warns for font-weights that are not compatible with Android", () => {
+    const css = ".foo { font-weight: 300 }";
+    expect.assertions(2);
+
+    return stylelint
+      .lint({
+        code: css,
+        formatter: "string",
+        config: {
+          extends: "./index"
+        }
+      })
+      .then(result => {
+        expect(result.errored).toBe(false);
+        expect(
+          result.output.includes(
+            "font-weight value other than 400, 700, normal or bold has not effect in React Native on Android"
+          )
+        ).toBe(true);
+      });
+  });
+
+  it("warns for incompatible @-rules", () => {
+    const css =
+      ".foo { @keyframes() { 0% { color: blue } 100% { color: red; } } }";
+    expect.assertions(2);
+
+    return stylelint
+      .lint({
+        code: css,
+        formatter: "string",
+        config: {
+          extends: "./index"
+        }
+      })
+      .then(result => {
+        expect(result.errored).toBe(false);
+        expect(
+          result.output.includes(
+            "the @-rule is ignored by React Native CSS modules"
+          )
+        ).toBe(true);
+      });
+  });
+
+  it("warns for incompatible units", () => {
+    const css = ".foo { font-size: 1ch; }";
+    expect.assertions(2);
+
+    return stylelint
+      .lint({
+        code: css,
+        formatter: "string",
+        config: {
+          extends: "./index"
+        }
+      })
+      .then(result => {
+        expect(result.errored).toBe(false);
+        expect(
+          result.output.includes(
+            "the unit is ignored by React Native CSS modules"
+          )
         ).toBe(true);
       });
   });
@@ -201,8 +308,8 @@ describe("stylelint-config-react-native-css-modules", () => {
         code: css,
         formatter: "string",
         config: {
-          extends: "./index",
-        },
+          extends: "./index"
+        }
       })
       .then(result => {
         expect(result.errored).toBe(false);

--- a/index.test.js
+++ b/index.test.js
@@ -245,7 +245,7 @@ describe("stylelint-config-react-native-css-modules", () => {
       })
       .then(result => {
         expect(result.errored).toBe(false);
-        expect(result.output.includes("font-weight value other than 400")).toBe(
+        expect(result.output.includes("font-weight value other than")).toBe(
           true
         );
       });

--- a/index.test.js
+++ b/index.test.js
@@ -245,9 +245,9 @@ describe("stylelint-config-react-native-css-modules", () => {
       })
       .then(result => {
         expect(result.errored).toBe(false);
-        expect(
-          result.output.includes("font-weight value other than 400, 700")
-        ).toBe(true);
+        expect(result.output.includes("font-weight value other than 400")).toBe(
+          true
+        );
       });
   });
 

--- a/index.test.js
+++ b/index.test.js
@@ -246,9 +246,7 @@ describe("stylelint-config-react-native-css-modules", () => {
       .then(result => {
         expect(result.errored).toBe(false);
         expect(
-          result.output.includes(
-            "font-weight value other than 400, 700, normal or bold has not effect in React Native on Android"
-          )
+          result.output.includes("font-weight value other than 400, 700")
         ).toBe(true);
       });
   });
@@ -268,11 +266,7 @@ describe("stylelint-config-react-native-css-modules", () => {
       })
       .then(result => {
         expect(result.errored).toBe(false);
-        expect(
-          result.output.includes(
-            "the @-rule is ignored by React Native CSS modules"
-          )
-        ).toBe(true);
+        expect(result.output.includes("the @-rule is ignored")).toBe(true);
       });
   });
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "peerDependencies": {
     "stylelint": "^8.0.0 || ^9.0.0",
-    "stylelint-react-native": "^1.0.0 || ^2.0.0"
+    "stylelint-react-native": "^2.0.0"
   }
 }


### PR DESCRIPTION
- Warn for font-weights that are not compatible with Android.
- Warn for @-rules that are not compatible with React Native CSS modules.
- Warn for units that are not compatible with React Native CSS modules.
- Show error when using prefixes in @-rules.